### PR TITLE
Prod Mode and File Loading Functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "axios": "^0.21.0",
     "dompurify": "^2.2.0",
+    "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "filenamify": "^4.2.0",
     "highlight.js": "^10.3.2",
@@ -47,6 +48,7 @@
     "boot-dev": "yarn install",
     "boot-prod": "yarn install && yarn build && yarn install --production",
     "dev": "node ./server/dev_server.js",
+    "start": "node ./server/server.js",
     "cleanup": "rm -rf .parcel-cache dist",
     "build": "yarn cleanup && npx parcel build \"src/views/editor.html\""
   }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "private": false,
   "dependencies": {
     "axios": "^0.21.0",
+    "digit-count": "^1.0.3",
     "dompurify": "^2.2.0",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
@@ -16,14 +17,17 @@
     "http-proxy-middleware": "^1.0.6",
     "lodash": "^4.17.20",
     "markdown-it": "^12.0.2",
+    "parse-numeric-range": "^1.2.0",
     "prop-types": "^15.7.2",
     "purecss": "^2.0.3",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "regenerator-runtime": "^0.13.7",
+    "relaxed-json": "^1.0.3",
     "strftime": "^0.10.0",
     "unused-filename": "^2.1.0",
     "url-join": "^4.0.1",
+    "wu": "^2.1.0",
     "yargs": "^16.1.0"
   },
   "devDependencies": {

--- a/server/server.js
+++ b/server/server.js
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+/* eslint-disable import/no-extraneous-dependencies */
+/* ^^ We're using this for development now, so simply skip the warnings here */
+const Path = require('path');
+const fs = require('fs');
+const process = require('process');
+const https = require('https');
+
+const yargs = require('yargs/yargs');
+const { hideBin } = require('yargs/helpers');
+const express = require('express');
+const dotenv = require('dotenv');
+
+const postBundler = require('./post_bundler');
+
+dotenv.config();
+
+const {
+  SSL_KEY_PATH: sslKeyPath,
+  SSL_CERT_PATH: sslCertPath,
+} = process.env;
+
+// Argument Setings
+const { argv } = yargs(hideBin(process.argv))
+  .usage('Usage: $0 [options]')
+  .example(
+    '$0 --port 4001 --img-dir ./imgs --out-dir ./result',
+    'Run the server at 4001, save output archives to "result" folder under root directory, '
+    + 'and using "img" folder to serach for images under root directory.',
+  )
+  .example(
+    '$0 -p 4001 -p ./imgs -o ./result',
+    'Do the same thing as above',
+  )
+  .options({
+    port: {
+      alias: 'p',
+      describe: 'Port of the server.',
+      type: 'number',
+      nargs: 1,
+      default: 4000,
+    },
+    'img-dir': {
+      alias: 'd',
+      describe: (
+        'Directory for accessing image content. '
+        + 'If you are using relative path, please note that the working '
+        + 'directory is "server" folder under the root directory.'
+      ),
+      type: 'string',
+      nargs: 1,
+      default: Path.normalize(Path.join(__dirname, 'img')),
+    },
+    'out-dir': {
+      alias: 'o',
+      describe: (
+        'Directory to save the bundled files. '
+        + 'If you are using relative path, please note that the working '
+        + 'directory is "server" folder under the root directory.'
+      ),
+      type: 'string',
+      nargs: 1,
+      default: Path.normalize(Path.join(__dirname, 'output')),
+    },
+  });
+
+const servicePort = argv.port;
+
+const fullImageDir = Path.normalize(argv['img-dir'].startsWith('.')
+  ? Path.join(__dirname, argv['img-dir'])
+  : argv['img-dir']);
+const fullOutputDir = Path.normalize(argv['out-dir'].startsWith('.')
+  ? Path.join(__dirname, argv['out-dir'])
+  : argv['out-dir']);
+const siteStaticDir = Path.join(__dirname, '../dist');
+
+// Force create directory as needed
+if (
+  !fs.existsSync(fullImageDir)
+  || !fs.lstatSync(fullImageDir).isDirectory()
+) {
+  fs.mkdirSync(fullImageDir);
+}
+
+// Start server and redirect requests
+const server = express();
+server.use(express.json());
+server.use('/', express.static(siteStaticDir));
+server.use('/img', express.static(argv['img-dir']));
+
+server.post('/bundle_document', async (req, res) => {
+  const { rawDocument, parsedDocument, documentMeta } = req.body;
+  const result = await postBundler(
+    fullImageDir, fullOutputDir, rawDocument, parsedDocument, documentMeta,
+  );
+  res.json(result);
+});
+
+const sslKey = fs.readFileSync(sslKeyPath);
+const sslCert = fs.readFileSync(sslCertPath);
+const mainServer = https.createServer({ key: sslKey, cert: sslCert }, server);
+
+mainServer.listen(servicePort, () => {
+  process.stdout.write(`Listening to port ${servicePort}...\n`);
+});

--- a/src/js/App.jsx
+++ b/src/js/App.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import regeneratorRuntime from 'regenerator-runtime';
+import 'regenerator-runtime';
 
 import MarkdownEditor from './MarkdownEditor';
 

--- a/src/js/MarkdownEditor/Constants/meta.js
+++ b/src/js/MarkdownEditor/Constants/meta.js
@@ -1,4 +1,4 @@
-const Version = '0.1.0';
+const Version = '0.2.0';
 
 const EditorMeta = {
   Version,

--- a/src/js/helpers/parser.js
+++ b/src/js/helpers/parser.js
@@ -303,8 +303,7 @@ function createSafeTabLinkRenderer(defaultRenderer) {
   // https://github.com/markdown-it/markdown-it/blob/master/docs/architecture.md#renderer
   return (tokens, idx, options, env, slf) => {
     let attrIdx = tokens[idx].attrIndex('href');
-
-    if ((attrIdx >= 0) && !isInternalLink(tokens[idx][attrIdx][1])) {
+    if ((attrIdx >= 0) && !isInternalLink(tokens[idx].attrs[attrIdx][1])) {
       attrIdx = tokens[idx].attrIndex('target');
       if (attrIdx < 0) {
         tokens[idx].attrPush(['target', '_blank']);

--- a/src/js/helpers/syntax_highlight.js
+++ b/src/js/helpers/syntax_highlight.js
@@ -402,7 +402,6 @@ class HljsDataProcessor {
   }
 }
 
-// {lineNum: true}
 function highlight(rawStr, lang, attrsRaw) {
   let langTag = (lang && hljs.getLanguage(lang)) ? lang : 'plaintext';
   let attrs;

--- a/src/js/helpers/syntax_highlight.js
+++ b/src/js/helpers/syntax_highlight.js
@@ -396,7 +396,7 @@ class HljsDataProcessor {
     );
     pipeline = HljsDataProcessor.processPreBlock(
       pipeline, ((limitHeight > 0) ? limitHeight : undefined),
-      this.LineCount, this.language, this.fileName,
+      this.lineCount, this.language, this.fileName,
     );
     return pipeline.reduce((prev, curr) => `${prev}${curr}`, '');
   }

--- a/src/js/helpers/syntax_highlight.js
+++ b/src/js/helpers/syntax_highlight.js
@@ -1,5 +1,3 @@
-/* eslint-disable no-unused-vars */
-
 /* Language support should be defined in this file to minimize bundle size.
  * Ref: https://github.com/highlightjs/highlight.js/blob/master/SUPPORTED_LANGUAGES.md
  */
@@ -17,6 +15,19 @@ import json from 'highlight.js/lib/languages/json';
 import markdown from 'highlight.js/lib/languages/markdown';
 import plaintext from 'highlight.js/lib/languages/plaintext';
 
+import rangeParser from 'parse-numeric-range';
+import digitCount from 'digit-count';
+import { parse as rJsonParse } from 'relaxed-json';
+import {
+  isInteger, isString, first, reduceRight, memoize, isEmpty,
+} from 'lodash';
+import wu, {
+  count,
+  zip as iterZip,
+  map as iterMap,
+  chain,
+} from 'wu';
+
 hljs.registerLanguage('javascript', javascript);
 hljs.registerLanguage('typescript', typescript);
 hljs.registerLanguage('bash', bash);
@@ -30,19 +41,408 @@ hljs.registerLanguage('json', json);
 hljs.registerLanguage('markdown', markdown);
 hljs.registerLanguage('plaintext', plaintext);
 
-function createHljsContent(parsedStr) {
-  return `<pre class="hljs">${parsedStr}</pre>`;
+// $1: Closing tag, $2: Tag name, $3: Class attr, $4: Class group, $5: Other attributes
+
+const fixClass = 'hljs-ln-fix';
+const lineNumberLabelClass = 'ln-num';
+const lineLabelClass = 'labled-ln';
+const lineLabelColorfillClass = 'labled-ln-color-fill';
+const lineContainerClass = 'hljs-ln-label-container';
+
+/*  Idea Source:
+  *  https://programmer.help/blogs/write-your-own-highlight.js-line-number-plugin.html
+  *
+  *  Notes:
+  *  - hljs's 3rd party plugin only deal with DOM and also not available for ES6 import
+  *  - The article's approach tackles copy-paste (disater on editors that support table
+  *    structure) pretty well but cannot work on old IEs. It also avoids the problem of
+  *    multi-line element, but still need to face it when it comes to line labeling.
+  *  - To mitigate this problem, we can complete all the incomplete tags in the line
+  *    at the end of the line. A stack is created to trace tags that are not closed.
+  *  - We assume that hljs's official language parser packs its HTML tags property and
+  *    never get crazy, which means:
+  *    (1) newline/return/carriage/etc. never appear within the tag description;
+  *    (2) it's a well-formed XML group;
+  *    (3) attributes are separated through white space (x20)
+  *    (3) 'class' attribute always exists, is always the first attribute, and enclosed
+  *        in double quotation marks.
+  */
+
+const PREPEND_LINE_NUMBER_KEY = 'prependLineNumber';
+const LABLE_LINES_KEY = 'labelLines';
+const LIMIT_HEIGHT_KEY = 'limitHeight';
+const LINE_NUMBER_ENABLED_SETTINGS_KEY = 'enabled';
+const LINE_NUMBER_START_SETTINGS_KEY = 'start';
+const LINENUM_BORDER_WIDTH_EM = 0.1;
+const HLJS_DEFAULT_PADDING_EM = 1;
+const LINENUM_PRESERVED_SPACE_EM = 0.5;
+const HLJS_LINE_HEIGHT_EM = 1.25;
+const CODE_TOP_PADDING_EM = 0.5;
+// Warning: (1) Magic Number (2) Does not work when mixed with full-width font
+const MONOSPACE_HEIGHT_WIDTH_RATIO = 0.65;
+const CODE_WINDOW_EXTRA_SPACE = 0.75; // TODO: Magic Number / Rename it
+
+class HljsDataProcessor {
+  constructor(rawStrInput, rawHtmlInput, language, fileName) {
+    this.rawHtmlInput = rawHtmlInput;
+    this.language = isString(language) ? language : '';
+    this.fileName = fileName;
+    [this.lineCount, this.maxLineLength] = HljsDataProcessor.getDocumetMeta(rawStrInput);
+    // TODO: Should be managed as state when start number changed.
+    this.lineDigits = digitCount(this.lineCount);
+    this.state = {
+      [PREPEND_LINE_NUMBER_KEY]: {
+        [LINE_NUMBER_ENABLED_SETTINGS_KEY]: false,
+        [LINE_NUMBER_START_SETTINGS_KEY]: 1,
+      },
+      [LABLE_LINES_KEY]: [],
+      [LIMIT_HEIGHT_KEY]: -1,
+    };
+
+    this.appendLineNumber = this.appendLineNumber.bind(this);
+    this.disableLineNumber = this.disableLineNumber.bind(this);
+    this.labelLines = this.labelLines.bind(this);
+    this.disableLabel = this.disableLineNumber.bind(this);
+    this.limitHeight = this.limitHeight.bind(this);
+    this.disableHeightLimit = this.disableHeightLimit.bind(this);
+    this.dump = memoize(this.dump.bind(this));
+  }
+
+  static getClosingTagsFix(tagTrace, oldClosedCount, newOpenedTags) {
+  /*
+    tagTrace: [oldKeptOuter...oldKeptInner, oldEndOuter...oldEndInner]
+    newOpenedTags: [newOuter...newInner]
+
+    Expected fix result:
+    opening: "<oldKeptOuter>...<oldKeptInner>" @ "<oldEndOuter>...<oldEndInner>"
+    closing: "<newInner>...<newOuter>" @ "<oldKeptInner><oldKeptOuter>"
+  */
+    const skipFrom = tagTrace.length - oldClosedCount;
+    const oldProcessed = reduceRight(
+      tagTrace,
+      ({ opening, closing }, [tagName, tagClass, otherAttrs], idx) => ({
+        opening: `<${tagName} class="${fixClass}${tagClass ? ` ${tagClass}` : ''}"${otherAttrs || ''}>${opening}`,
+        closing: `${closing}${(idx >= skipFrom) ? '' : `</${tagName}>`}`,
+      }),
+      { opening: '', closing: '' },
+    );
+
+    const res = reduceRight(
+      newOpenedTags,
+      ({ opening, closing }, [tagName]) => ({
+        opening,
+        closing: `${closing}</${tagName}>`,
+      }),
+      oldProcessed,
+    );
+    return res;
+  }
+
+  static updateTagTrace(tagTrace, oldClosedCount, newOpenedTags) {
+    // Pop off closed tags and append newly opened tags.
+    let remainder = oldClosedCount;
+    while (remainder !== 0) {
+      tagTrace.pop();
+      remainder -= 1;
+    }
+    remainder = newOpenedTags.length;
+    while (remainder !== 0) {
+      tagTrace.push(newOpenedTags.shift());
+      remainder -= 1;
+    }
+  }
+
+  static processTagFix(line, tagTrace) { // private method
+    const htmlTagRegex = /<(\/)?([A-Za-z][A-Za-z0-9]*)(\x20+class="([^>"]*)")?([^>]*)?>/g;
+
+    // Note for updates:
+    // [tag1, tag2, tag3] <-- Initial
+    //   (Some tags may be closed in current line)
+    // [tag1, tag2^, tag3^] <-- After Closing Happens
+    //   (Some new tags may be unclosed here)
+    // [tag1, tag2^, tag3^], [tag4, tag5] <-- After the whole reading process
+    let oldClosedCount = 0;
+    const newOpenedTags = []; // stack: [outer...inner]
+
+    let tagMatchResult = htmlTagRegex.exec(line);
+    while (tagMatchResult !== null) {
+      const [, closed, tagName, , tagClass, otherAttrs] = tagMatchResult;
+      if (closed !== undefined) {
+        // Skip tag checking because we expect a well-formed XML
+        if (isEmpty(newOpenedTags)) {
+          oldClosedCount += 1;
+        } else {
+          newOpenedTags.pop();
+        }
+      } else {
+        newOpenedTags.push([tagName, tagClass, otherAttrs]);
+      }
+      tagMatchResult = htmlTagRegex.exec(line);
+    }
+    const { opening, closing } = HljsDataProcessor.getClosingTagsFix(
+      tagTrace, oldClosedCount, newOpenedTags,
+    );
+    HljsDataProcessor.updateTagTrace(tagTrace, oldClosedCount, newOpenedTags);
+
+    return `${opening}${line}${closing}`;
+  }
+
+  static getDocumetMeta(input) {
+    const newlineRegex = /\r\n|\r|\n/g;
+    let lineCount = 0;
+    let headIdx = 0;
+    let endIdx = 0;
+    let maxLineLength = 0;
+    let lineMatchResult = newlineRegex.exec(input);
+    while (lineMatchResult !== null) {
+      const [lineFeed] = lineMatchResult;
+      headIdx = endIdx;
+      endIdx = newlineRegex.lastIndex - lineFeed.length;
+      maxLineLength = Math.max(maxLineLength, endIdx - headIdx);
+      lineCount += 1;
+      lineMatchResult = newlineRegex.exec(input);
+    }
+
+    return [lineCount, maxLineLength];
+  }
+
+  static* hljsPrerocessedLineIter(input) {
+    // Line split and take the best effort to preserve newline characters.
+    const newlineRegex = /\r\n|\r|\n/g;
+    let startIndex = 0;
+    let newLineIndex = 0;
+    let endIndex = 0;
+
+    let lineMatchResult = newlineRegex.exec(input);
+    let lineContent = '';
+    let newlineStr = '';
+    const tagTrace = [];
+
+    if (input) {
+      while (lineMatchResult !== null) {
+        [newlineStr] = lineMatchResult;
+        startIndex = endIndex;
+        endIndex = newlineRegex.lastIndex;
+        newLineIndex = endIndex - newlineStr.length;
+        lineContent = input.slice(startIndex, newLineIndex);
+
+        lineMatchResult = newlineRegex.exec(input);
+        if (lineMatchResult) {
+          yield [`${HljsDataProcessor.processTagFix(lineContent, tagTrace)}`, newlineStr];
+        } else {
+          // Currently, Markdown-it preserves the newline between code and closing fence
+          // and we need to discard it. This will cause unwanted problem when we're wrapping
+          // with additional tags
+          yield [`${HljsDataProcessor.processTagFix(lineContent, tagTrace)}`, ''];
+        }
+      }
+      // For the same reason, input should be fully consumed here.
+    }
+  }
+
+  /* Functional components */
+  static zipLineNumber(iter, start) {
+    // iterable(any) => wIter([any, int])
+    return iterZip(iter, count(start));
+  }
+
+  static discardLineNumber(wIter) {
+    // wIter([[string, string], int]) => wIter([string, string])
+    return wIter.map((v) => first(v));
+  }
+
+  static lineFeedMergeMapper([lineContent, lineFeed]) {
+    return `${lineContent}${lineFeed}`;
+  }
+
+  static mergeLineFeed(wIter) {
+    // wIter([string, string]) => wIter(string)
+    return wIter.map(HljsDataProcessor.lineFeedMergeMapper);
+  }
+
+  static lineNumberMapper([[lineContent, lineFeed], lineNum]) {
+    return [
+      [
+        `<span class="${lineNumberLabelClass}" data-num="${lineNum}"></span>${lineContent}`,
+        lineFeed,
+      ],
+      lineNum,
+    ];
+  }
+
+  static processLineNumber(wIter) {
+    // wIter([[string, string], int]) => wIter([[string, string], int])
+    return wIter.map(HljsDataProcessor.lineNumberMapper);
+  }
+
+  static labelLine(offset) {
+    const computedStyle = `style="top: ${HLJS_LINE_HEIGHT_EM * offset + CODE_TOP_PADDING_EM}em"`;
+    return `<span class="${lineLabelClass}" ${computedStyle}><span class="${lineLabelColorfillClass}">\n</span></span>`;
+  }
+
+  static processLineLabel(wIter, lineList, offset, maxLineCount, maxLineLength, lineDigits) {
+    // (old) wIter([[string, string], int]) => wIter([[string, string], int])
+    // (new) wIter(string) => wIter(string)
+    if (isEmpty(lineList)) {
+      return wIter;
+    }
+    const extraSpace = (lineDigits !== undefined)
+      ? lineDigits + LINENUM_PRESERVED_SPACE_EM + LINENUM_BORDER_WIDTH_EM
+      : 0;
+    const calculatedStyle = ` style="width: ${maxLineLength * MONOSPACE_HEIGHT_WIDTH_RATIO + extraSpace}em;">`;
+
+    return chain(
+      wIter,
+      [`<div class="${lineContainerClass}"${calculatedStyle}`],
+      (
+        iterMap((lineNum) => (lineNum - offset), lineList)
+          .filter((lineOffset) => (lineOffset >= 0 && lineOffset < maxLineCount))
+          .map(HljsDataProcessor.labelLine)
+      ),
+      ['</div>'],
+    );
+  }
+
+  static processLineNumberHeader(iter, lineDigits) {
+    // wIter(string) => wIter(string)
+    const calculatedStyle = `style="width: ${lineDigits + LINENUM_PRESERVED_SPACE_EM + LINENUM_BORDER_WIDTH_EM}em"`;
+    return chain([`<span class="ln-bg" ${calculatedStyle}></span>`], iter);
+  }
+
+  static processCodeBlock(iter, lineEnabled, lineDigits) {
+    // Adding required surrounding tags for hljs element
+    // wIter(string) => wIter(string)
+    const lineClass = lineEnabled ? ' hljs-ln' : '';
+    const calculatedStyle = (
+      lineEnabled
+        ? ` style="padding-left: ${HLJS_DEFAULT_PADDING_EM + lineDigits + LINENUM_PRESERVED_SPACE_EM + LINENUM_BORDER_WIDTH_EM}em"`
+        : ''
+    );
+    return chain([`<code class="hljs${lineClass}"${calculatedStyle}>`], iter, ['</code>']);
+  }
+
+  static processPreBlock(iter, maxLines, lineCount, language, fileName) {
+    const calculatedStyle = (maxLines !== undefined)
+      ? ` style="max-height: ${maxLines * HLJS_LINE_HEIGHT_EM + CODE_WINDOW_EXTRA_SPACE}em;"`
+      : '';
+    const langAttr = ` language="${language}"`;
+    const linesAttr = ` lines=${lineCount}`;
+    const fileNameAttr = fileName ? ` file-name="${fileName}"` : '';
+    return chain([`<pre${calculatedStyle}${langAttr}${linesAttr}${fileNameAttr}>`], iter, ['</pre>']);
+  }
+  /* End of Functional components */
+
+  appendLineNumber(start) {
+    this.state[PREPEND_LINE_NUMBER_KEY] = {
+      [LINE_NUMBER_ENABLED_SETTINGS_KEY]: true,
+      [LINE_NUMBER_START_SETTINGS_KEY]: start,
+    };
+
+    return this;
+  }
+
+  disableLineNumber() {
+    this.state[PREPEND_LINE_NUMBER_KEY] = {
+      [LINE_NUMBER_ENABLED_SETTINGS_KEY]: false,
+      [LINE_NUMBER_START_SETTINGS_KEY]: 1,
+    };
+
+    return this;
+  }
+
+  labelLines(lines) {
+    this.state[LABLE_LINES_KEY] = lines;
+
+    return this;
+  }
+
+  disableLabel() {
+    this.state[LABLE_LINES_KEY] = [];
+
+    return this;
+  }
+
+  limitHeight(maxLines) {
+    this.state[LIMIT_HEIGHT_KEY] = maxLines;
+
+    return this;
+  }
+
+  disableHeightLimit() {
+    this.state[LIMIT_HEIGHT_KEY] = -1;
+
+    return this;
+  }
+
+  dump() { // Memoized. (Accept input in the future?)
+    const { prependLineNumber, labelLines, limitHeight } = this.state;
+    const { enabled: lineEnabled, start: lineStart } = prependLineNumber;
+
+    let pipeline = wu(HljsDataProcessor.hljsPrerocessedLineIter(this.rawHtmlInput));
+    pipeline = HljsDataProcessor.zipLineNumber(pipeline, lineStart);
+    if (lineEnabled) {
+      pipeline = HljsDataProcessor.processLineNumber(pipeline);
+    }
+
+    pipeline = HljsDataProcessor.discardLineNumber(pipeline);
+    pipeline = HljsDataProcessor.mergeLineFeed(pipeline);
+    if (lineEnabled) {
+      pipeline = HljsDataProcessor.processLineNumberHeader(pipeline, this.lineDigits);
+    }
+    pipeline = HljsDataProcessor.processCodeBlock(pipeline, lineEnabled, this.lineDigits);
+    pipeline = HljsDataProcessor.processLineLabel(
+      pipeline, labelLines, lineStart, this.lineCount, this.maxLineLength,
+      (lineEnabled ? this.lineDigits : undefined),
+    );
+    pipeline = HljsDataProcessor.processPreBlock(
+      pipeline, ((limitHeight > 0) ? limitHeight : undefined),
+      this.LineCount, this.language, this.fileName,
+    );
+    return pipeline.reduce((prev, curr) => `${prev}${curr}`, '');
+  }
 }
 
-// Customized highlight support
-function highlight(rawStr, lang) {
-  const langTag = (lang && hljs.getLanguage(lang)) ? lang : 'plaintext';
+// {lineNum: true}
+function highlight(rawStr, lang, attrsRaw) {
+  let langTag = (lang && hljs.getLanguage(lang)) ? lang : 'plaintext';
+  let attrs;
   try {
-    return createHljsContent(hljs.highlight(langTag, rawStr, true).value);
+    attrs = rJsonParse(attrsRaw);
   } catch (__) {
-    // Fallback to process input as plaintext
-    return createHljsContent(hljs.highlight('plaintext', rawStr).value);
+    attrs = {};
   }
+  const {
+    lineNum, labeled, maxLines, fileName,
+  } = attrs;
+  let { lineNumStart } = attrs;
+  let parsedHtml = '';
+  const labeledLines = [];
+
+  try {
+    parsedHtml = hljs.highlight(langTag, rawStr, false).value;
+  } catch (__) {
+    // Fallback to process as pure text
+    langTag = 'plaintext';
+    parsedHtml = hljs.highlight('plaintext', rawStr).value;
+  }
+
+  let pipeline = new HljsDataProcessor(rawStr, parsedHtml, langTag, fileName);
+
+  if (lineNum === true) {
+    lineNumStart = (isInteger(lineNumStart) && lineNumStart > 0) ? lineNumStart : 1;
+    pipeline = pipeline.appendLineNumber(lineNumStart);
+  }
+
+  if (isString(labeled)) {
+    labeledLines.push(...rangeParser(labeled));
+    pipeline = pipeline.labelLines(labeledLines);
+  }
+
+  if (isInteger(maxLines) && maxLines > 0) {
+    pipeline = pipeline.limitHeight(maxLines);
+  }
+
+  return pipeline.dump();
 }
 
 export default highlight;

--- a/src/scss/editor.scss
+++ b/src/scss/editor.scss
@@ -78,6 +78,7 @@ body {
 
   & > * {
     box-sizing: border-box;
+    min-width: 0;
   }
 }
 
@@ -223,8 +224,6 @@ body {
 }
 
 .preview-content {
-  display: flex;
-  flex-direction: row;
   margin: 4px;
   border-width: 1px;
   border-style: dotted;

--- a/src/scss/editor.scss
+++ b/src/scss/editor.scss
@@ -1,3 +1,4 @@
+@use "../../node_modules/purecss/build/base-min.css";
 @use "markdown";
 @use "fonts";
 
@@ -167,6 +168,7 @@ body {
     flex-grow: 2;
     height: 0;
     width: 100%;
+    white-space: nowrap;
     overflow-y: scroll;
     resize: none;
     padding: 8px;
@@ -221,6 +223,8 @@ body {
 }
 
 .preview-content {
+  display: flex;
+  flex-direction: row;
   margin: 4px;
   border-width: 1px;
   border-style: dotted;

--- a/src/scss/markdown.scss
+++ b/src/scss/markdown.scss
@@ -236,7 +236,7 @@ $font-crimson: "Crimson Pro";
     .labled-ln-color-fill {
       display: block;
       line-height: inherit;
-      background-color: #525852;
+      background-color: #031D03;
       box-sizing: border-box;
       user-select: none;
     }

--- a/src/scss/markdown.scss
+++ b/src/scss/markdown.scss
@@ -1,3 +1,5 @@
+@use "../../node_modules/highlight.js/scss/agate.scss";
+
 /* Layout for GitHub-Flavoured Markdown */
 $green-darker-olive: #2B3618;
 $green-dark-olive: #556B2F;
@@ -171,5 +173,13 @@ $grey-lighter: #EDEDED;
     border-radius: 2px;
     border-color: $grey-light;
     background-color: $grey-lighter;
+  }
+
+  // To deal with long inline content we need help from flex box model to
+  // confine width
+  .hljs {
+    width: 0;
+    flex-grow: 1;
+    overflow-x: scroll;
   }
 }

--- a/src/scss/markdown.scss
+++ b/src/scss/markdown.scss
@@ -7,6 +7,8 @@ $yellow-light: #FFFFE0;
 $yellow-papayawhip: #FFEFD5;
 $grey-light: #D3D3D3;
 $grey-lighter: #EDEDED;
+$font-code: Consolas, "Courier New", Courier, monospace;
+$font-redhat: "Red Hat Display";
 
 @mixin markdown {
   // Reset margins
@@ -20,7 +22,7 @@ $grey-lighter: #EDEDED;
   h4,
   h5,
   h6 {
-    font-family: "Red Hat Display";
+    font-family: $font-redhat;
   }
 
   h1,
@@ -165,6 +167,7 @@ $grey-lighter: #EDEDED;
 
   // Inline code. Preindented one will be managed by highightJS
   code {
+    font-family: $font-code;
     font-size: 0.85em;
     line-height: 0.85em;
     padding: 0 0.25em;
@@ -175,11 +178,82 @@ $grey-lighter: #EDEDED;
     background-color: $grey-lighter;
   }
 
-  // To deal with long inline content we need help from flex box model to
-  // confine width
-  .hljs {
-    width: 0;
-    flex-grow: 1;
-    overflow-x: scroll;
+  pre {
+    font-family: $font-code;
+    display: block;
+    position: relative;
+    overflow-x: auto;
+    padding: 0.5em 0 0.5em 1em;
+    background-color: #333;
+
+    // Overwrite inline code & hljs theme settings
+    code, code.hljs {
+      display: inline-block;    // Need inline layout to get correct width
+      position: relative;       // Allow hacks like line highlight/labeling
+      overflow: hidden; // Has some problem on pixel calculation, so prevent scrolling here
+      background: none;         // Let <pre> cover background.
+      color: white;
+      border: none;
+      padding: 0 2em 0 0;
+      font-size: 1em;
+      line-height: 1.25em;
+      z-index: 2;
+    }
+  }
+
+  .hljs-ln-label-container {
+    display: block;
+    position: absolute;
+    left: 0;
+    top: 0;
+    min-width: 100%;
+    z-index: 0;
+  }
+
+  .labled-ln {
+    display: block;
+    position: absolute;
+    left: 0;
+    padding-left: 1em;
+    width: 100%;
+    line-height: 1.25em;
+    box-sizing: border-box;
+
+    .labled-ln-color-fill {
+      display: block;
+      line-height: inherit;
+      background-color: #525852;
+      box-sizing: border-box;
+    }
+  }
+
+  .hljs-ln {
+    .ln-bg {
+      position: absolute;
+      z-index: 1;
+      top: 0;
+      left: 0;
+      height: 100%;
+      border-right: 1px solid yellow;
+      background: none;
+    }
+
+    .ln-num {
+      position: relative;
+      line-height: 1.25em;
+      user-select: none;
+    }
+
+    .ln-num::before {
+      position: absolute;
+      z-index: 3;
+      top: 0;
+      right: 0;
+      margin-right: 1.25em;
+      color: yellow;
+      font-style: normal;
+      font-weight: normal;
+      content: attr(data-num);
+    }
   }
 }

--- a/src/scss/markdown.scss
+++ b/src/scss/markdown.scss
@@ -9,6 +9,7 @@ $grey-light: #D3D3D3;
 $grey-lighter: #EDEDED;
 $font-code: Consolas, "Courier New", Courier, monospace;
 $font-redhat: "Red Hat Display";
+$font-crimson: "Crimson Pro";
 
 @mixin markdown {
   // Reset margins
@@ -22,7 +23,7 @@ $font-redhat: "Red Hat Display";
   h4,
   h5,
   h6 {
-    font-family: $font-redhat;
+    font-family: 'Red Hat Display';
   }
 
   h1,
@@ -62,8 +63,11 @@ $font-redhat: "Red Hat Display";
     color: #696969;
   }
 
-  p, blockquote, ol, ul {
-    font-family: "Crimson Pro";
+  p,
+  blockquote,
+  ol,
+  ul {
+    font-family: 'Crimson Pro';
     margin: 0.3em 0 0 0;
     line-height: 1.25em;
   }
@@ -93,7 +97,11 @@ $font-redhat: "Red Hat Display";
   hr {
     border: 0;
     height: 1px;
-    background-image: linear-gradient(to right, rgba(0, 0, 0, 0.75), rgba(0, 0, 0, 0));
+    background-image: linear-gradient(
+      to right,
+      rgba(0, 0, 0, 0.75),
+      rgba(0, 0, 0, 0)
+    );
   }
 
   a,
@@ -112,7 +120,8 @@ $font-redhat: "Red Hat Display";
   }
 
   // Prevent nested font growth.
-  ol, ul {
+  ol,
+  ul {
     list-style-position: inside;
     margin-left: 18px;
     font-size: 18px;
@@ -152,15 +161,19 @@ $font-redhat: "Red Hat Display";
     align-items: center;
     background-color: #FFFFFF;
     padding: 8px;
+    max-width: 75%;
+    margin-left: auto;
+    margin-right: auto;
 
     // Cap the image if it's too large.
     img {
-      max-width: 75%;
+      display: block;
+      width: 100%;
     }
 
     img + .caption {
       margin-top: 4px;
-      font-family: "Crimson Pro";
+      font-family: $font-crimson;
       line-height: 1.25em;
     }
   }
@@ -218,12 +231,14 @@ $font-redhat: "Red Hat Display";
     width: 100%;
     line-height: 1.25em;
     box-sizing: border-box;
+    user-select: none;
 
     .labled-ln-color-fill {
       display: block;
       line-height: inherit;
       background-color: #525852;
       box-sizing: border-box;
+      user-select: none;
     }
   }
 

--- a/src/views/editor.html
+++ b/src/views/editor.html
@@ -5,8 +5,6 @@
   <meta http-equiv="X-UA-Compatible">
   <meta charset="utf-8">
   <title>Markdown Editor</title>
-  <link rel="stylesheet" href="../../node_modules/purecss/build/base-min.css">
-  <link rel="stylesheet" href="../../node_modules/highlight.js/scss/agate.scss">
   <link rel="stylesheet" href="../scss/editor.scss">
 </head>
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3309,6 +3309,11 @@ dotenv@^7.0.0:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-7.0.0.tgz#a2be3cd52736673206e8a85fb5210eea29628e7c"
   integrity sha512-M3NhsLbV1i6HuGzBUH8vXrtxOk+tWmzWKDMbAVSUp3Zsjm7ywFeuwrUXhmhQyRK1q5B5GGy7hcXPbj3bnfZg2g==
 
+dotenv@^8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
+  integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
+
 ecc-jsbn@~0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz#3a83a904e54353287874c564b7549386849a98c9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2710,7 +2710,7 @@ command-exists@^1.2.6:
   resolved "https://registry.yarnpkg.com/command-exists/-/command-exists-1.2.9.tgz#c50725af3808c8ab0260fd60b01fbfa25b954f69"
   integrity sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==
 
-commander@^2.19.0, commander@^2.20.0:
+commander@^2.19.0, commander@^2.20.0, commander@^2.6.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -3194,6 +3194,11 @@ diffie-hellman@^5.0.0:
     bn.js "^4.1.0"
     miller-rabin "^4.0.0"
     randombytes "^2.0.0"
+
+digit-count@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/digit-count/-/digit-count-1.0.3.tgz#b27db0812cb5589760d97c0506edc15c3199fd93"
+  integrity sha1-sn2wgSy1WJdg2XwFBu3BXDGZ/ZM=
 
 doctrine@1.5.0:
   version "1.5.0"
@@ -5738,6 +5743,11 @@ parse-json@^5.0.0:
     json-parse-even-better-errors "^2.3.0"
     lines-and-columns "^1.1.6"
 
+parse-numeric-range@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/parse-numeric-range/-/parse-numeric-range-1.2.0.tgz#aa70b00f29624ed13e9f943e9461b306e386b0fa"
+  integrity sha512-1q2tXpAOplPxcl8vrIGPWz1dJxxfmdRkCFcpxxMBerDnGuuHalOWF/xj9L8Nn5XoTUoB/6F0CeQBp2fMgkOYFg==
+
 parse5@5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-5.1.0.tgz#c59341c9723f414c452975564c7c00a68d58acd2"
@@ -6615,6 +6625,14 @@ relateurl@^0.2.7:
   version "0.2.7"
   resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
   integrity sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=
+
+relaxed-json@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/relaxed-json/-/relaxed-json-1.0.3.tgz#eb2101ae0ee60e82267d95ed0ddf19a3604b8c1e"
+  integrity sha512-b7wGPo7o2KE/g7SqkJDDbav6zmrEeP4TK2VpITU72J/M949TLe/23y/ZHJo+pskcGM52xIfFoT9hydwmgr1AEg==
+  dependencies:
+    chalk "^2.4.2"
+    commander "^2.6.0"
 
 repeat-element@^1.1.2:
   version "1.1.3"
@@ -7839,6 +7857,11 @@ ws@^6.1.2, ws@^6.2.0:
   integrity sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==
   dependencies:
     async-limiter "~1.0.0"
+
+wu@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/wu/-/wu-2.1.0.tgz#7e72e3fba23e0ff669ddd537e1c857d3d4b1614f"
+  integrity sha1-fnLj+6I+D/Zp3dU34chX09SxYU8=
 
 xml-name-validator@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
# Purpose and Details
 - Previously the editor's working in development mode and linked with `Parcel`'s bundler/watcher. Once the development's done it should be run in production mode without the bundler. An extra script for prod mode is needed for this purpose without Parcel's interference.
 - An editor, even a simple one, should be able to load from stored file/archive. I need this functionality to edit undone post from midway.

   Problem/challenge comes in several ways:
    - `npm`'s tar module are unreliable so unpacking tar bundle should be processed at backend.
    - "*Load File from Browser => Send Duplicated File Content to Backend => Unpack Archive => ...*" is cumbersome.
    - Backend knows nothing about browser client's file system, so some communication protocol is needed for both ends. For instance, assigning a folder to store all the bundles and let backend share/sync the information with frontend. By doing so, backend will provide list of bundles to client for selection, and unpack + deliver content as client demands.
    - How do we manage image conflict when unpacking tar file?

# TODO List
 - [ ] Complete prod mode script (progress: fix the script for dev mode)
 - [ ] ~~Adding archive loading functionality~~ (for the next update)